### PR TITLE
Define before to fix #88

### DIFF
--- a/src/file.cc
+++ b/src/file.cc
@@ -1,3 +1,7 @@
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS 1
+#endif
+
 #include "getmode.h"
 #include "uv.h"
 
@@ -9,10 +13,6 @@
 #ifndef __WIN32
 #include <grp.h>
 #include <pwd.h>
-#endif
-
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS 1
 #endif
 
 #include <inttypes.h>


### PR DESCRIPTION
Seems it was related to this issue: https://stackoverflow.com/questions/14535556/why-doesnt-priu64-work-in-this-code.

Defining the MACRO at the beginning fixed the problem for my computer (#88 )