### PR TITLE
Edit docs for path_*() family

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -132,10 +132,10 @@ path_abs <- function(path, start = ".") {
 }
 
 
-#' @describeIn path_math collapses redundant separators and up-level references,
-#'   so `A//B`, `A/B`, `A/./B` and `A/foo/../B` all become `A/B`. If one of the
-#'   paths is a symbolic link, this may change the meaning of the path, in this
-#'   case one should use `path_real()` prior to calling `path_norm()`.
+#' @describeIn path_math eliminates `.` references and rationalizes up-level
+#'   `..` references, so `A/./B` and `A/foo/../B` both become `A/B`, but `../B`
+#'   is not changed. If one of the paths is a symbolic link, this may change the
+#'   meaning of the path, so consider using `path_real()` instead.
 #' @export
 path_norm <- function(path) {
   non_missing <- !is.na(path)

--- a/R/path.R
+++ b/R/path.R
@@ -1,17 +1,15 @@
 #' Path computations
 #'
-#' All functions apart from [path_expand()] and [path_real()] are purely
-#' path computations, so the files in question do not need to exist on the
-#' filesystem.
+#' All functions apart from `path_real()` are purely path computations, so the
+#' files in question do not need to exist on the filesystem.
 #' @template fs
 #' @name path_math
-#' @return The new path as a character vector. For [path_split()], a list of
-#'   character vectors of path components is returned instead.
+#' @return The new path(s) in an `fs_path` object, which is a character vector
+#'   that also has class `fs_path`. Except `path_split()`, which returns a list
+#'   of character vectors of path components.
+#' @seealso [path_expand()] for expansion of user's home directory.
 #' @examples
 #' \dontshow{.old_wd <- setwd(tempdir())}
-#' # Expand a path
-#' path_expand("~/bin")
-#'
 #' dir_create("a")
 #' file_create("a/b")
 #' link_create(path_abs("a"), "c")
@@ -62,7 +60,8 @@ path <- function(..., ext = "") {
 }
 
 #' @describeIn path_math returns the canonical path, eliminating any symbolic
-#' links.
+#'   links and the special references `~`, `~user`, `.`, and `..`, , i.e. it
+#'   calls `path_expand()` (literally) and `path_norm()` (effectively).
 #' @export
 path_real <- function(path) {
   path <- enc2utf8(path)
@@ -82,7 +81,8 @@ path_real <- function(path) {
 #' multiple `/` or trailing `/` and have colourised output based on the file
 #' type.
 #'
-#' @return A fs_path object
+#' @return An `fs_path` object, which is a character vector that also has class
+#'   `fs_path`
 #' @template fs
 #' @export
 path_tidy <- function(path) {
@@ -106,7 +106,8 @@ path_split <- function(path) {
 
 #' @describeIn path_math joins parts together. The inverse of [path_split()].
 #' See [path()] to concatenate vectorized strings into a path.
-#' @param parts A list of character vectors, corresponding to split paths.
+#' @param parts A character vector or a list of character vectors, corresponding
+#'   to split paths.
 #' @export
 path_join <- function(parts) {
   if (length(parts) == 0) {
@@ -131,11 +132,10 @@ path_abs <- function(path, start = ".") {
 }
 
 
-#' @describeIn path_math collapses redundant separators and
-#' up-level references, so `A//B`, `A/B`, `A/./B` and `A/foo/../B` all become
-#' `A/B`. If one of the paths is a symbolic link, this may change the meaning
-#' of the path, in this case one should use [path_real()] prior to calling
-#' [path_norm()].
+#' @describeIn path_math collapses redundant separators and up-level references,
+#'   so `A//B`, `A/B`, `A/./B` and `A/foo/../B` all become `A/B`. If one of the
+#'   paths is a symbolic link, this may change the meaning of the path, in this
+#'   case one should use `path_real()` prior to calling `path_norm()`.
 #' @export
 path_norm <- function(path) {
   non_missing <- !is.na(path)
@@ -171,9 +171,9 @@ path_norm <- function(path) {
 }
 
 #' @describeIn path_math computes the path relative to the `start` path,
-#'   which can be either a absolute or relative path.
+#'   which can be either an absolute or relative path.
 #' @export
-#' @param start A starting directory to compute the path to.
+#' @param start A starting directory to compute the path relative to.
 # This implementation is partially derived from
 # https://github.com/python/cpython/blob/9c99fd163d5ca9bcc0b7ddd0d1e3b8717a63237c/Lib/posixpath.py#L446
 path_rel <- function(path, start = ".") {
@@ -215,38 +215,42 @@ path_rel <- function(path, start = ".") {
 #' * `path_expand()` performs tilde expansion on a path, replacing instances of
 #' `~` or `~user` with the user's home directory.
 #' * `path_home()` constructs a path within the expanded users home directory,
-#'   calling it with _no_ arguments can be useful to verify what fs considers the
-#'   home directory.
+#' calling it with _no_ arguments can be useful to verify what fs considers the
+#' home directory.
 #' * `path_expand_r()` and `path_home_r()` are equivalents which always use R's
-#'   definition of the home directory.
+#' definition of the home directory.
 #' @details
-#' `path_expand()` Differs from [path.expand()] in the interpretation of the
-#' home directory of Windows. In particular `path_expand()` uses the path set
-#' in `USERPROFILE`, if unset then `HOMEDRIVE`/`HOMEPATH` is used.
+#' `path_expand()` differs from [base::path.expand()] in the interpretation of
+#' the home directory of Windows. In particular `path_expand()` uses the path
+#' set in the `USERPROFILE` environment variable and, if unset, then uses
+#' `HOMEDRIVE`/`HOMEPATH`.
 #'
-#' In contrast [path.expand()] first checks for `R_USER` then `HOME`, which in the default
-#' configuration of R on Windows are both set to the users document directory, e.g.
-#' `C:\\Users\\username\\Documents`. `path.expand()` also does not support
-#' `~otheruser` syntax on Windows, whereas `path_expand()` does support this
-#' syntax on all systems.
+#' In contrast [base::path.expand()] first checks for `R_USER` then `HOME`,
+#' which in the default configuration of R on Windows are both set to the user's
+#' document directory, e.g. `C:\\Users\\username\\Documents`.
+#' [base::path.expand()] also does not support `~otheruser` syntax on Windows,
+#' whereas `path_expand()` does support this syntax on all systems.
 #'
-#' This definition makes fs more consistent with the definition of home directory used
-#' on Windows in other languages, such as
+#' This definition makes fs more consistent with the definition of home
+#' directory used on Windows in other languages, such as
 #' [python](https://docs.python.org/3/library/os.path.html#os.path.expanduser)
-#' and [rust](https://doc.rust-lang.org/std/env/fn.home_dir.html#windows).
-#' This is also more compatible with external tools such as git and ssh, both of
-#' which put user-level files in `USERPROFILE` by default. It also allows you
-#' to write portable paths, such as `~/Desktop` that points to the Desktop
-#' location on Windows, MacOS and (most) Linux systems.
+#' and [rust](https://doc.rust-lang.org/std/env/fn.home_dir.html#windows). This
+#' is also more compatible with external tools such as git and ssh, both of
+#' which put user-level files in `USERPROFILE` by default. It also allows you to
+#' write portable paths, such as `~/Desktop` that points to the Desktop location
+#' on Windows, MacOS and (most) Linux systems.
 #'
 #' Users can set the `R_FS_HOME` environment variable to override the
 #' definitions on any platform.
 #' @seealso [R for Windows FAQ - 2.14](https://cran.r-project.org/bin/windows/base/rw-FAQ.html#What-are-HOME-and-working-directories_003f)
 #' for behavior of [base::path.expand()].
-#' @param ... Additional paths appended to the home directory by `path()`.
+#' @param ... Additional paths appended to the home directory by [path()].
 #' @inheritParams path_math
 #' @export
 #' @examples
+#' # Expand a path
+#' path_expand("~/bin")
+#'
 #' # You can use `path_home()` without arguments to see what is being used as
 #' # the home diretory.
 #' path_home()
@@ -285,13 +289,13 @@ path_home_r <- function(...) {
 #' Manipulate file paths
 #'
 #' `path_file()` returns the filename portion of the path, `path_dir()` returns
-#' the directory portion. `path_ext()` returns the last extension (if any) for a path.
-#' `path_ext_remove()` removes the last extension and returns the rest of the
-#' path. `path_ext_set()` replaces the extension with a new extension. If there
-#' is no existing extension the new extension is appended.
+#' the directory portion. `path_ext()` returns the last extension (if any) for a
+#' path. `path_ext_remove()` removes the last extension and returns the rest of
+#' the path. `path_ext_set()` replaces the extension with a new extension. If
+#' there is no existing extension the new extension is appended.
 #' @template fs
 #' @param ext,value The new file extension.
-#' @seealso [basename()], [dirname()]
+#' @seealso [base::basename()], [base::dirname()]
 #' @export
 #' @examples
 #' path_file("dir/file.zip")

--- a/man/path_expand.Rd
+++ b/man/path_expand.Rd
@@ -18,7 +18,7 @@ path_home_r(...)
 \arguments{
 \item{path}{A character vector of one or more paths.}
 
-\item{...}{Additional paths appended to the home directory by \code{path()}.}
+\item{...}{Additional paths appended to the home directory by \code{\link[=path]{path()}}.}
 }
 \description{
 \itemize{
@@ -32,29 +32,33 @@ definition of the home directory.
 }
 }
 \details{
-\code{path_expand()} Differs from \code{\link[=path.expand]{path.expand()}} in the interpretation of the
-home directory of Windows. In particular \code{path_expand()} uses the path set
-in \code{USERPROFILE}, if unset then \code{HOMEDRIVE}/\code{HOMEPATH} is used.
+\code{path_expand()} differs from \code{\link[base:path.expand]{base::path.expand()}} in the interpretation of
+the home directory of Windows. In particular \code{path_expand()} uses the path
+set in the \code{USERPROFILE} environment variable and, if unset, then uses
+\code{HOMEDRIVE}/\code{HOMEPATH}.
 
-In contrast \code{\link[=path.expand]{path.expand()}} first checks for \code{R_USER} then \code{HOME}, which in the default
-configuration of R on Windows are both set to the users document directory, e.g.
-\code{C:\\Users\\username\\Documents}. \code{path.expand()} also does not support
-\code{~otheruser} syntax on Windows, whereas \code{path_expand()} does support this
-syntax on all systems.
+In contrast \code{\link[base:path.expand]{base::path.expand()}} first checks for \code{R_USER} then \code{HOME},
+which in the default configuration of R on Windows are both set to the user's
+document directory, e.g. \code{C:\\Users\\username\\Documents}.
+\code{\link[base:path.expand]{base::path.expand()}} also does not support \code{~otheruser} syntax on Windows,
+whereas \code{path_expand()} does support this syntax on all systems.
 
-This definition makes fs more consistent with the definition of home directory used
-on Windows in other languages, such as
+This definition makes fs more consistent with the definition of home
+directory used on Windows in other languages, such as
 \href{https://docs.python.org/3/library/os.path.html#os.path.expanduser}{python}
-and \href{https://doc.rust-lang.org/std/env/fn.home_dir.html#windows}{rust}.
-This is also more compatible with external tools such as git and ssh, both of
-which put user-level files in \code{USERPROFILE} by default. It also allows you
-to write portable paths, such as \code{~/Desktop} that points to the Desktop
-location on Windows, MacOS and (most) Linux systems.
+and \href{https://doc.rust-lang.org/std/env/fn.home_dir.html#windows}{rust}. This
+is also more compatible with external tools such as git and ssh, both of
+which put user-level files in \code{USERPROFILE} by default. It also allows you to
+write portable paths, such as \code{~/Desktop} that points to the Desktop location
+on Windows, MacOS and (most) Linux systems.
 
 Users can set the \code{R_FS_HOME} environment variable to override the
 definitions on any platform.
 }
 \examples{
+# Expand a path
+path_expand("~/bin")
+
 # You can use `path_home()` without arguments to see what is being used as
 # the home diretory.
 path_home()

--- a/man/path_file.Rd
+++ b/man/path_file.Rd
@@ -28,10 +28,10 @@ path_ext(path) <- value
 }
 \description{
 \code{path_file()} returns the filename portion of the path, \code{path_dir()} returns
-the directory portion. \code{path_ext()} returns the last extension (if any) for a path.
-\code{path_ext_remove()} removes the last extension and returns the rest of the
-path. \code{path_ext_set()} replaces the extension with a new extension. If there
-is no existing extension the new extension is appended.
+the directory portion. \code{path_ext()} returns the last extension (if any) for a
+path. \code{path_ext_remove()} removes the last extension and returns the rest of
+the path. \code{path_ext_set()} replaces the extension with a new extension. If
+there is no existing extension the new extension is appended.
 }
 \examples{
 path_file("dir/file.zip")
@@ -48,5 +48,5 @@ path_ext_remove("file.tar.gz")
 path_ext_set(path_ext_remove("file.tar.gz"), "zip")
 }
 \seealso{
-\code{\link[=basename]{basename()}}, \code{\link[=dirname]{dirname()}}
+\code{\link[base:basename]{base::basename()}}, \code{\link[base:dirname]{base::dirname()}}
 }

--- a/man/path_math.Rd
+++ b/man/path_math.Rd
@@ -55,10 +55,10 @@ See \code{\link[=path]{path()}} to concatenate vectorized strings into a path.
 
 \item \code{path_abs}: returns a normalized, absolute version of a path.
 
-\item \code{path_norm}: collapses redundant separators and up-level references,
-so \code{A//B}, \code{A/B}, \code{A/./B} and \code{A/foo/../B} all become \code{A/B}. If one of the
-paths is a symbolic link, this may change the meaning of the path, in this
-case one should use \code{path_real()} prior to calling \code{path_norm()}.
+\item \code{path_norm}: eliminates \code{.} references and rationalizes up-level
+\code{..} references, so \code{A/./B} and \code{A/foo/../B} both become \code{A/B}, but \code{../B}
+is not changed. If one of the paths is a symbolic link, this may change the
+meaning of the path, so consider using \code{path_real()} instead.
 
 \item \code{path_rel}: computes the path relative to the \code{start} path,
 which can be either an absolute or relative path.

--- a/man/path_math.Rd
+++ b/man/path_math.Rd
@@ -28,23 +28,25 @@ path_common(path)
 \arguments{
 \item{path}{A character vector of one or more paths.}
 
-\item{parts}{A list of character vectors, corresponding to split paths.}
+\item{parts}{A character vector or a list of character vectors, corresponding
+to split paths.}
 
-\item{start}{A starting directory to compute the path to.}
+\item{start}{A starting directory to compute the path relative to.}
 }
 \value{
-The new path as a character vector. For \code{\link[=path_split]{path_split()}}, a list of
-character vectors of path components is returned instead.
+The new path(s) in an \code{fs_path} object, which is a character vector
+that also has class \code{fs_path}. Except \code{path_split()}, which returns a list
+of character vectors of path components.
 }
 \description{
-All functions apart from \code{\link[=path_expand]{path_expand()}} and \code{\link[=path_real]{path_real()}} are purely
-path computations, so the files in question do not need to exist on the
-filesystem.
+All functions apart from \code{path_real()} are purely path computations, so the
+files in question do not need to exist on the filesystem.
 }
 \section{Functions}{
 \itemize{
 \item \code{path_real}: returns the canonical path, eliminating any symbolic
-links.
+links and the special references \code{~}, \code{~user}, \code{.}, and \code{..}, , i.e. it
+calls \code{path_expand()} (literally) and \code{path_norm()} (effectively).
 
 \item \code{path_split}: splits paths into parts.
 
@@ -53,23 +55,19 @@ See \code{\link[=path]{path()}} to concatenate vectorized strings into a path.
 
 \item \code{path_abs}: returns a normalized, absolute version of a path.
 
-\item \code{path_norm}: collapses redundant separators and
-up-level references, so \code{A//B}, \code{A/B}, \code{A/./B} and \code{A/foo/../B} all become
-\code{A/B}. If one of the paths is a symbolic link, this may change the meaning
-of the path, in this case one should use \code{\link[=path_real]{path_real()}} prior to calling
-\code{\link[=path_norm]{path_norm()}}.
+\item \code{path_norm}: collapses redundant separators and up-level references,
+so \code{A//B}, \code{A/B}, \code{A/./B} and \code{A/foo/../B} all become \code{A/B}. If one of the
+paths is a symbolic link, this may change the meaning of the path, in this
+case one should use \code{path_real()} prior to calling \code{path_norm()}.
 
 \item \code{path_rel}: computes the path relative to the \code{start} path,
-which can be either a absolute or relative path.
+which can be either an absolute or relative path.
 
 \item \code{path_common}: finds the common parts of two (or more) paths.
 }}
 
 \examples{
 \dontshow{.old_wd <- setwd(tempdir())}
-# Expand a path
-path_expand("~/bin")
-
 dir_create("a")
 file_create("a/b")
 link_create(path_abs("a"), "c")
@@ -100,4 +98,7 @@ path_common(c("/foo/bar/baz", "/foo/bar/abc", "/foo/xyz/123"))
 dir_delete("a")
 link_delete("c")
 \dontshow{setwd(.old_wd)}
+}
+\seealso{
+\code{\link[=path_expand]{path_expand()}} for expansion of user's home directory.
 }

--- a/man/path_tidy.Rd
+++ b/man/path_tidy.Rd
@@ -10,7 +10,8 @@ path_tidy(path)
 \item{path}{A character vector of one or more paths.}
 }
 \value{
-A fs_path object
+An \code{fs_path} object, which is a character vector that also has class
+\code{fs_path}
 }
 \description{
 untidy paths are all different, tidy paths are all the same.


### PR DESCRIPTION
* Backtick (not link) when documented in same file
* Link (not backtick) when documented in different file
* Qualify with `base::` in places where easy to be confused
* `path_expand()` is not documented in main "path_math" Rd file
* Be more explicit re: return values and work done by each function
* Re-flow / re-linewrap