### PR TITLE
Extra flag needed for new toolchain

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -13,7 +13,7 @@ SOURCES = $(wildcard *.cc windows/*.cc)
 OBJECTS = $(SOURCES:.cc=.o) RcppExports.o
 
 # Additional flags for libuv borrowed from libuv/Makefile.mingw
-LIBUV_CFLAGS = -Iinclude -Isrc -Isrc/win -DWIN32_LEAN_AND_MEAN
+LIBUV_CFLAGS = -Iinclude -Isrc -Isrc/win -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0600
 
 $(SHLIB): libuv/libuv.a
 


### PR DESCRIPTION
Same issue as https://github.com/rstudio/httpuv/pull/160. See also [build log](https://github.com/r-windows/checks/blob/master/fs.Rcheck/00install.out) with new toolchain.