### PR TITLE
`path` argument is not used in `path()` or `path_wd()`

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -47,7 +47,6 @@ NULL
 #' `path()` constructs a relative path, `path_wd()` constructs an absolute path
 #' from the current working directory.
 #'
-#' @template fs
 #' @param ... character vectors, if any values are NA, the result will also be
 #'   NA.
 #' @param ext An optional extension to append to the generated path.

--- a/man/path.Rd
+++ b/man/path.Rd
@@ -14,8 +14,6 @@ path_wd(..., ext = "")
 NA.}
 
 \item{ext}{An optional extension to append to the generated path.}
-
-\item{path}{A character vector of one or more paths.}
 }
 \description{
 \code{path()} constructs a relative path, \code{path_wd()} constructs an absolute path


### PR DESCRIPTION
I was inheriting args from `path()` and found that this template shouldn't be included.