### PR TITLE
Remove -p flag

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -26,7 +26,7 @@ all: $(SHLIB)
 $(SHLIB): libuv/.libs/libuv.a
 
 libuv/m4/lt~obsolete.m4: libuv/m4/lt_obsolete.m4
-	cp -p -f libuv/m4/lt_obsolete.m4 libuv/m4/lt~obsolete.m4
+	cp -f libuv/m4/lt_obsolete.m4 libuv/m4/lt~obsolete.m4
 
 libuv/Makefile: libuv/m4/lt~obsolete.m4
 	(cd libuv \

--- a/src/libuv/Makefile.in
+++ b/src/libuv/Makefile.in
@@ -4617,7 +4617,7 @@ distdir: $(DISTFILES)
 	    cp -fpR $$d/$$file "$(distdir)$$dir" || exit 1; \
 	  else \
 	    test -f "$(distdir)/$$file" \
-	    || cp -p $$d/$$file "$(distdir)/$$file" \
+	    || cp $$d/$$file "$(distdir)/$$file" \
 	    || exit 1; \
 	  fi; \
 	done


### PR DESCRIPTION
Dear `fs` maintainers,

Is there a reason the -p flag is being used during the build? It causes the installation to fail when installing the package on an NFS filesystem:

```
> install.packages("fs")
...
cp -p -f libuv/m4/lt_obsolete.m4 libuv/m4/lt~obsolete.m4
cp: preserving permissions for ‘libuv/m4/lt~obsolete.m4’: Operation not supported
make: *** [libuv/m4/lt~obsolete.m4] Error 1
ERROR: compilation failed for package ‘fs’
```

In this pull request, I removed the -p flag, and am now able to install the package successfully.

Kind regards,
Robrecht
