### PR TITLE
file_temp() - add period to extension if supplied

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * `colourise_fs_path()` now returns paths uncolored if the colors argument /
   `LS_COLORS` is malformed (#135).
+  
+* The `ext` argument of `file_temp()` is now consistent with other functions in
+  fs and prepends a `.` to the file extension if provided.
 
 # fs 1.2.6
 

--- a/R/temp.R
+++ b/R/temp.R
@@ -26,10 +26,12 @@ env$temp_names <- character()
 #' path_temp()
 #' path_temp("does-not-exist")
 #'
-#' # default just passes the arguments to `tempfile()`
 #' file_temp()
+#' file_temp(ext = "png")
+#' file_temp("image", ext = "png")
 #'
-#' # But you can also make the results deterministic
+#'
+#' # You can make the temp file paths deterministic
 #' file_temp_push(letters)
 #' file_temp()
 #' file_temp()
@@ -39,6 +41,9 @@ env$temp_names <- character()
 #' file_temp_pop()
 file_temp <- function(pattern = "file", tmp_dir = tempdir(), ext = "") {
   assert_no_missing(tmp_dir)
+
+  prepend_dot <- function(ext) ifelse(nchar(ext), paste0(".", ext), ext)
+  ext <- vapply(ext, prepend_dot, character(1))
 
   path_tidy(file_temp_pop() %||% tempfile(pattern, tmp_dir, ext))
 }

--- a/R/temp.R
+++ b/R/temp.R
@@ -42,8 +42,8 @@ env$temp_names <- character()
 file_temp <- function(pattern = "file", tmp_dir = tempdir(), ext = "") {
   assert_no_missing(tmp_dir)
 
-  prepend_dot <- function(ext) ifelse(nchar(ext), paste0(".", ext), ext)
-  ext <- vapply(ext, prepend_dot, character(1))
+  has_extension <- nzchar(ext)
+  ext[has_extension] <- paste0(".", ext[has_extension])
 
   path_tidy(file_temp_pop() %||% tempfile(pattern, tmp_dir, ext))
 }

--- a/tests/testthat/test-temp.R
+++ b/tests/testthat/test-temp.R
@@ -7,6 +7,18 @@ test_that("file_temp() returns unique temporary files", {
   }
 })
 
+test_that("file_temp() extension applied correctly", {
+  tmp_no_ext <- file_temp()
+  tmp_has_ext <- file_temp(ext = "pdf")
+  expect_equal(path_ext(tmp_no_ext), "")
+  expect_equal(path_ext(tmp_has_ext), "pdf")
+
+  exts = c("xlsx", "doc", "")
+  tmpfile_multiple <- tempfile(fileext = paste0(c(".", ".", ""), exts))
+  file_temp_multiple <- file_temp(ext = exts)
+  expect_equal(path_ext(file_temp_multiple), path_ext(tmpfile_multiple))
+})
+
 test_that("file_temp() can use have deterministic results if desired", {
   prev <- file_temp()
   file_temp_push(c("foo", "bar", "baz", "bar"))


### PR DESCRIPTION
Resolves #136 by prepending a `.` to the file extension `ext` before passing to `tempfile()`.

I also made some minor edits to the documentation (did not roxygenize) and added tests and a NEWS entry.