### PR TITLE
Added library that declares mode_t

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2,6 +2,7 @@
 // Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 #include <Rcpp.h>
+#include <sys/stat.h>
 
 using namespace Rcpp;
 


### PR DESCRIPTION
I found a problem while compiling the package on alpine linux (docker image), after am internet search, I believe this will suffice, the log is:
```
* installing *source* package ‘fs’ ...
** package ‘fs’ successfully unpacked and MD5 sums checked
** libs
g++  -I/usr/include/R -DNDEBUG -I./libuv/include -I. -I"/usr/lib/R/library/Rcpp/include" -Os -fomit-frame-pointer   -fpic  -Os -fomit-frame-pointer -D__MUSL__  -c error.cc -o error.o
g++  -I/usr/include/R -DNDEBUG -I./libuv/include -I. -I"/usr/lib/R/library/Rcpp/include" -Os -fomit-frame-pointer   -fpic  -Os -fomit-frame-pointer -D__MUSL__  -c dir.cc -o dir.o
g++  -I/usr/include/R -DNDEBUG -I./libuv/include -I. -I"/usr/lib/R/library/Rcpp/include" -Os -fomit-frame-pointer   -fpic  -Os -fomit-frame-pointer -D__MUSL__  -c fs.cc -o fs.o
g++  -I/usr/include/R -DNDEBUG -I./libuv/include -I. -I"/usr/lib/R/library/Rcpp/include" -Os -fomit-frame-pointer   -fpic  -Os -fomit-frame-pointer -D__MUSL__  -c path.cc -o path.o
g++  -I/usr/include/R -DNDEBUG -I./libuv/include -I. -I"/usr/lib/R/library/Rcpp/include" -Os -fomit-frame-pointer   -fpic  -Os -fomit-frame-pointer -D__MUSL__  -c link.cc -o link.o
g++  -I/usr/include/R -DNDEBUG -I./libuv/include -I. -I"/usr/lib/R/library/Rcpp/include" -Os -fomit-frame-pointer   -fpic  -Os -fomit-frame-pointer -D__MUSL__  -c utils.cc -o utils.o
g++  -I/usr/include/R -DNDEBUG -I./libuv/include -I. -I"/usr/lib/R/library/Rcpp/include" -Os -fomit-frame-pointer   -fpic  -Os -fomit-frame-pointer -D__MUSL__  -c file.cc -o file.o
g++  -I/usr/include/R -DNDEBUG -I./libuv/include -I. -I"/usr/lib/R/library/Rcpp/include" -Os -fomit-frame-pointer   -fpic  -Os -fomit-frame-pointer -D__MUSL__  -c id.cc -o id.o
g++  -I/usr/include/R -DNDEBUG -I./libuv/include -I. -I"/usr/lib/R/library/Rcpp/include" -Os -fomit-frame-pointer   -fpic  -Os -fomit-frame-pointer -D__MUSL__  -c unix/getmode.cc -o unix/getmode.o
g++  -I/usr/include/R -DNDEBUG -I./libuv/include -I. -I"/usr/lib/R/library/Rcpp/include" -Os -fomit-frame-pointer   -fpic  -Os -fomit-frame-pointer -D__MUSL__  -c RcppExports.cpp -o RcppExports.o
RcppExports.cpp:9:35: error: 'mode_t' has not been declared
 void mkdir_(CharacterVector path, mode_t mode);
                                   ^~~~~~
RcppExports.cpp: In function 'SEXPREC* _fs_mkdir_(SEXP, SEXP)':
RcppExports.cpp:14:36: error: 'mode_t' was not declared in this scope
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                    ^~~~~~
RcppExports.cpp:14:43: error: template argument 1 is invalid
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                           ^
RcppExports.cpp:14:51: error: expected initializer before 'mode'
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                                   ^~~~
RcppExports.cpp:15:18: error: 'mode' was not declared in this scope
     mkdir_(path, mode);
                  ^~~~
RcppExports.cpp: At global scope:
RcppExports.cpp:57:36: error: 'mode_t' has not been declared
 void create_(CharacterVector path, mode_t mode);
                                    ^~~~~~
RcppExports.cpp: In function 'SEXPREC* _fs_create_(SEXP, SEXP)':
RcppExports.cpp:62:36: error: 'mode_t' was not declared in this scope
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                    ^~~~~~
RcppExports.cpp:62:43: error: template argument 1 is invalid
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                           ^
RcppExports.cpp:62:51: error: expected initializer before 'mode'
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                                   ^~~~
RcppExports.cpp:63:19: error: 'mode' was not declared in this scope
     create_(path, mode);
                   ^~~~
RcppExports.cpp: At global scope:
RcppExports.cpp:158:1: error: 'mode_t' does not name a type
 mode_t getmode_(const char* mode_str, mode_t mode);
 ^~~~~~
RcppExports.cpp: In function 'SEXPREC* _fs_getmode_(SEXP, SEXP)':
RcppExports.cpp:164:36: error: 'mode_t' was not declared in this scope
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                    ^~~~~~
RcppExports.cpp:164:43: error: template argument 1 is invalid
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                           ^
RcppExports.cpp:164:51: error: expected initializer before 'mode'
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                                   ^~~~
RcppExports.cpp:165:53: error: 'mode' was not declared in this scope
     rcpp_result_gen = Rcpp::wrap(getmode_(mode_str, mode));
                                                     ^~~~
RcppExports.cpp:165:57: error: 'getmode_' was not declared in this scope
     rcpp_result_gen = Rcpp::wrap(getmode_(mode_str, mode));
                                                         ^
RcppExports.cpp: At global scope:
RcppExports.cpp:170:22: error: 'mode_t' was not declared in this scope
 std::string strmode_(mode_t mode);
                      ^~~~~~
RcppExports.cpp: In function 'SEXPREC* _fs_strmode_(SEXP)':
RcppExports.cpp:175:36: error: 'mode_t' was not declared in this scope
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                    ^~~~~~
RcppExports.cpp:175:43: error: template argument 1 is invalid
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                           ^
RcppExports.cpp:175:51: error: expected initializer before 'mode'
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                                   ^~~~
RcppExports.cpp:176:43: error: 'mode' was not declared in this scope
     rcpp_result_gen = Rcpp::wrap(strmode_(mode));
                                           ^~~~
RcppExports.cpp: At global scope:
RcppExports.cpp:181:42: error: 'mode_t' has not been declared
 std::string file_code_(std::string path, mode_t mode);
                                          ^~~~~~
RcppExports.cpp: In function 'SEXPREC* _fs_file_code_(SEXP, SEXP)':
RcppExports.cpp:187:36: error: 'mode_t' was not declared in this scope
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                    ^~~~~~
RcppExports.cpp:187:43: error: template argument 1 is invalid
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                           ^
RcppExports.cpp:187:51: error: expected initializer before 'mode'
     Rcpp::traits::input_parameter< mode_t >::type mode(modeSEXP);
                                                   ^~~~
RcppExports.cpp:188:51: error: 'mode' was not declared in this scope
     rcpp_result_gen = Rcpp::wrap(file_code_(path, mode));
                                                   ^~~~
make: *** [/usr/lib/R/etc/Makeconf:166: RcppExports.o] Error 1
ERROR: compilation failed for package ‘fs’
* removing ‘/usr/lib/R/library/fs’
```
