### PR TITLE
Add -pthread to fix pthread_atfork

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -17,6 +17,7 @@ PKG_LIBS += -lkvm
 endif
 ifeq ($(UNAME), Linux)
 OBJECTS +=  bsd/setmode.o bsd/strmode.o bsd/reallocarray.o
+PKG_LIBS += -pthread
 endif
 
 PKG_CPPFLAGS = -I./libuv/include -I.


### PR DESCRIPTION
Dear ```fs``` maintainers,

In order for me to install ```fs``` with ```R 3.3.3 (2017-03-06)``` on Raspbian Stretch I had to add  ```-pthread```.

Could you add this to the Linux verification ?