### PR TITLE
Parameter `browser` in `file_show()` fixed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Development
 
+* Parameter `browser` in `file_show()` now works as described in the documentation (#154 by GegznaV) 
+
 * Link with -pthread by default (#128, #146)
 
 * `path_real()` now works even if the file does not exist, but there are

--- a/R/file.R
+++ b/R/file.R
@@ -153,7 +153,7 @@ file_show <- function(path = ".", browser = getOption("browser")) {
   old <- path_expand(path)
 
   for (p in path) {
-    browseURL(p)
+    browseURL(p, browser = browser)
   }
 
   invisible(path_tidy(path))


### PR DESCRIPTION
The parameter `browser` was not used in the body the function `file_show()` thus it was not working as expected.