### PR TITLE
Fixed compilation-issue on FreeBSD.

### DIFF
--- a/src/unix/getmode.cc
+++ b/src/unix/getmode.cc
@@ -1,6 +1,7 @@
 #include "getmode.h"
 
-#if (defined(__APPLE__) && defined(__MACH__)) || defined(__BSD__)
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(__BSD__) ||    \
+    defined(__FreeBSD__)
 #include <string.h> /* for strmode */
 #include <unistd.h> /* for getmode / setmode */
 #else


### PR DESCRIPTION
The __BSD__ macro is not defined on FreeBSD causing a conflicting declaration to be made in "bsd/string.h". 