### PR TITLE
Add default to path argument in dir_tree()

### DIFF
--- a/R/tree.R
+++ b/R/tree.R
@@ -2,7 +2,7 @@
 #'
 #' @param path A path to print the tree from
 #' @export
-dir_tree <- function(path) {
+dir_tree <- function(path = ".") {
   files <- dir_ls(path, recursive = TRUE)
   by_dir <- split(files, path_dir(files))
 

--- a/man/dir_tree.Rd
+++ b/man/dir_tree.Rd
@@ -4,7 +4,7 @@
 \alias{dir_tree}
 \title{Print contents of directories in a tree-like format}
 \usage{
-dir_tree(path)
+dir_tree(path = ".")
 }
 \arguments{
 \item{path}{A path to print the tree from}


### PR DESCRIPTION
Thanks for `dir_tree()`, I love it! For consistency with `dir_ls()`, should `dir_tree()` work without a `path` argument?