### PR TITLE
Test that path_rel() can be reversed by path_abs().

### DIFF
--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -438,6 +438,13 @@ describe("path_rel", {
     expect_equal(path_rel(NA_character_), NA_character_)
     expect_equal(path_rel("/foo/bar/baz", NA_character_), NA_character_)
   })
+
+  it("can be reversed by path_abs", {
+    f <- file_temp()
+    expect_equal(path_abs(path_rel(f)), f)
+    home <- path_home()
+    expect_equal(path_abs(path_rel(f, start = home), start = home), f)
+  })
 })
 
 describe("path_abs", {


### PR DESCRIPTION
This is related to Issues #144 and #174.

On macOS, the temp directory is a symlink, which wouldn't be resolved
unless it existed. Now that path_real() resolves symlinks in the path
even if the target destination does not exist, this test should pass
even on macOS machines with symlinked temp directories.

On winbuilder, getwd() returns d:/ and tempdir() returns D:/, which
caused problems with path_rel(). Now that tidy paths always capitalize
the Windows drive, this test should pass on winbuilder.