### PR TITLE
Only deploy docs for main repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
       script: Rscript -e 'pkgdown::deploy_site_github()'
       skip_cleanup: true
       on:
+        repo: r-lib/fs
         condition: $TRAVIS_BRANCH = master || -n $TRAVIS_TAG
   - r: oldrel
   - r: 3.3


### PR DESCRIPTION
I have Travis CI set up for my fork, and my master branch unexpectedly failed. I realized it was because it was trying to deploy to GitHub Pages without deploy keys. This PR changes this so that it only deploys the pkgdown site for the main repository.