### PR TITLE
pass additional arguments from `dir_tree` to `dir_ls`

### DIFF
--- a/R/list.R
+++ b/R/list.R
@@ -15,7 +15,6 @@
 #' @param type File type(s) to return, one or more of "any", "file", "directory",
 #'   "symlink", "FIFO", "socket", "character_device" or "block_device".
 #' @param recursive Should directories be listed recursively?
-#'   the filenames.
 #' @inheritParams path_filter
 #' @param all If `TRUE` hidden files are also returned.
 #' @param fail Should the call fail (the default) or warn if a file cannot be

--- a/R/tree.R
+++ b/R/tree.R
@@ -1,9 +1,12 @@
 #' Print contents of directories in a tree-like format
 #'
 #' @param path A path to print the tree from
+#' @param recursive Should directories be printed recursively?
+#' @param ... Additional arguments passed to [dir_ls].
+#'
 #' @export
-dir_tree <- function(path = ".") {
-  files <- dir_ls(path, recursive = TRUE)
+dir_tree <- function(path = ".", recursive = TRUE, ...) {
+  files <- dir_ls(path, recursive = recursive, ...)
   by_dir <- split(files, path_dir(files))
 
   ch <- box_chars()

--- a/R/tree.R
+++ b/R/tree.R
@@ -1,7 +1,7 @@
 #' Print contents of directories in a tree-like format
 #'
 #' @param path A path to print the tree from
-#' @param recursive Should directories be printed recursively?
+#' @inheritParams dir_ls
 #' @param ... Additional arguments passed to [dir_ls].
 #'
 #' @export

--- a/man/dir_ls.Rd
+++ b/man/dir_ls.Rd
@@ -24,8 +24,7 @@ dir_info(path = ".", all = FALSE, recursive = FALSE, type = "any",
 
 \item{all}{If \code{TRUE} hidden files are also returned.}
 
-\item{recursive}{Should directories be listed recursively?
-the filenames.}
+\item{recursive}{Should directories be listed recursively?}
 
 \item{type}{File type(s) to return, one or more of "any", "file", "directory",
 "symlink", "FIFO", "socket", "character_device" or "block_device".}

--- a/man/dir_tree.Rd
+++ b/man/dir_tree.Rd
@@ -9,8 +9,7 @@ dir_tree(path = ".", recursive = TRUE, ...)
 \arguments{
 \item{path}{A path to print the tree from}
 
-\item{recursive}{Should directories be listed recursively?
-the filenames.}
+\item{recursive}{Should directories be listed recursively?}
 
 \item{...}{Additional arguments passed to \link{dir_ls}.}
 }

--- a/man/dir_tree.Rd
+++ b/man/dir_tree.Rd
@@ -9,7 +9,8 @@ dir_tree(path = ".", recursive = TRUE, ...)
 \arguments{
 \item{path}{A path to print the tree from}
 
-\item{recursive}{Should directories be printed recursively?}
+\item{recursive}{Should directories be listed recursively?
+the filenames.}
 
 \item{...}{Additional arguments passed to \link{dir_ls}.}
 }

--- a/man/dir_tree.Rd
+++ b/man/dir_tree.Rd
@@ -4,10 +4,14 @@
 \alias{dir_tree}
 \title{Print contents of directories in a tree-like format}
 \usage{
-dir_tree(path = ".")
+dir_tree(path = ".", recursive = TRUE, ...)
 }
 \arguments{
 \item{path}{A path to print the tree from}
+
+\item{recursive}{Should directories be printed recursively?}
+
+\item{...}{Additional arguments passed to \link{dir_ls}.}
 }
 \description{
 Print contents of directories in a tree-like format


### PR DESCRIPTION
Modified the function declaration for `dir_tree`.

The previous implementation of `dir_tree` called `dir_ls` with `recursive=TRUE`, so I added recursive = TRUE as an explicit argument in `dir_tree`.

Any other `dir_ls` arguments can be passed-through using the "..." argument in `dir_tree`.

API: `dir_tree(path = ".", recursive = TRUE, ...)`