### PR TITLE
Return tibbles only if the package is available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Suggests:
     testthat,
     covr,
     pillar (>= 1.0.0),
+    tibble (>= 1.1.0),
     crayon,
     rmarkdown,
     knitr,

--- a/R/stat.R
+++ b/R/stat.R
@@ -1,0 +1,15 @@
+stat <- function(path, fail) {
+  as_tibble(stat_(path, fail))
+}
+
+as_tibble <- function(x) {
+  if (is_installed("tibble")) {
+    tibble::as_tibble(x)
+  } else {
+    x
+  }
+}
+
+is_installed <- function(pkg) {
+  isTRUE(requireNamespace(pkg, quietly = TRUE))
+}

--- a/src/file.cc
+++ b/src/file.cc
@@ -261,7 +261,7 @@ List stat_(CharacterVector path, bool fail) {
     uv_fs_req_cleanup(&req);
   }
   out.attr("names") = names;
-  out.attr("class") = CharacterVector::create("tbl", "tbl_df", "data.frame");
+  out.attr("class") = CharacterVector::create("data.frame");
   out.attr("row.names") = IntegerVector::create(NA_INTEGER, -i);
 
   return out;


### PR DESCRIPTION
for stable subsetting behavior and automatic pretty printing if tibble is installed.