### PR TITLE
tildes get expanded in file list, so need to be expanded in dir_tree

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fs (development version)
 
+* `dir_tree()` now works with paths that need tilde expansion (@dmurdoch, @jennybc, #203).
+
 * `dir_create()` now works with absolute paths and `recurse = FALSE` (#204).
 
 # fs 1.3.1

--- a/R/tree.R
+++ b/R/tree.R
@@ -30,7 +30,7 @@ dir_tree <- function(path = ".", recurse = TRUE, ...) {
   }
 
   cat(colourise_fs_path(path), "\n", sep = "")
-  print_leaf(path, "")
+  print_leaf(path_expand(path), "")
 
   invisible(files)
 }


### PR DESCRIPTION
As pointed out in issue #203  `dir_tree("~")` fails.  The problem is that it expands the tilde when generating the file list, then searches that list for the directory with the tilde in it.  This patch fixes that.