### PR TITLE
Change a stray path_file_sanitize() to path_sanitize() in documentation

### DIFF
--- a/R/sanitize.R
+++ b/R/sanitize.R
@@ -1,6 +1,6 @@
 #' Sanitize a filename by removing directory paths and invalid characters
 #'
-#' `path_file_sanitize()` removes the following:
+#' `path_sanitize()` removes the following:
 #' - [Control characters](https://en.wikipedia.org/wiki/C0_and_C1_control_codes)
 #' - [Reserved characters](https://kb.acronis.com/content/39790)
 #' - Unix reserved filenames (`.` and `..`)

--- a/man/path_sanitize.Rd
+++ b/man/path_sanitize.Rd
@@ -12,7 +12,7 @@ path_sanitize(filename, replacement = "")
 \item{replacement}{A character vector used to replace invalid characters.}
 }
 \description{
-\code{path_file_sanitize()} removes the following:
+\code{path_sanitize()} removes the following:
 \itemize{
 \item \href{https://en.wikipedia.org/wiki/C0_and_C1_control_codes}{Control characters}
 \item \href{https://kb.acronis.com/content/39790}{Reserved characters}


### PR DESCRIPTION
The documentation for `path_sanitize()` still refers to it as `path_file_sanitize()` in one place -- updated it to `path_sanitize()`.