### PR TITLE
Pre-emptively expand path in dir_tree()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fs (development version)
 
+* `dir_tree()` now works with paths that need tilde expansion (@jennybc, #203).
+
 * `dir_create()` now works with absolute paths and `recurse = FALSE` (#204).
 
 # fs 1.3.1

--- a/R/tree.R
+++ b/R/tree.R
@@ -6,6 +6,7 @@
 #'
 #' @export
 dir_tree <- function(path = ".", recurse = TRUE, ...) {
+  path <- path_expand(path)
   files <- dir_ls(path, recurse = recurse, ...)
   by_dir <- split(files, path_dir(files))
 


### PR DESCRIPTION
Fixes #203

Right before I made this PR, I rediscovered the existing report (#203) and another PR (#212), so take whichever one you want.

The point is that `print_leaf()` must be called on the version of `path` that appears in the output of `dir_ls()`, which we all seem to agree is produced by `path_expand()`. To me it felt safer to pre-expand right away, but maybe it's fine (or better?) to expand in the `print_leaf()` call.