### PR TITLE
pass along CPPFLAGS when compiling libuv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # fs (development version)
 
+* fs now passes along CPPFLAGS during compilation of libuv, fixing an issue that could
+  prevent compilation from source on macOS Catalina. (@kevinushey, #229)
+  
 * `dir_tree()` now works with paths that need tilde expansion (@dmurdoch, @jennybc, #203).
 * `is_dir()`, `is_file()`, `is_file_empty()` and `file_info()` gain a `follow`
   argument, to follow links and return information about the linked file rather

--- a/src/Makevars
+++ b/src/Makevars
@@ -32,7 +32,7 @@ libuv/Makefile: libuv/m4/lt~obsolete.m4
 	(cd libuv \
 		&& touch aclocal.m4 \
 		&& touch -r aclocal.m4 configure Makefile.in \
-	&& CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure --quiet)
+	&& CC="$(CC)" CFLAGS="$(CFLAGS) $(CPPFLAGS) $(CPICFLAGS) $(C_VISIBILITY)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure --quiet)
 
 libuv/.libs/libuv.a: libuv/Makefile
 	$(MAKE) --directory=libuv \


### PR DESCRIPTION
Closes #229.

Note that this will only work for newer versions of R, where the appropriate path to system headers is set by R:

```
CPPFLAGS = -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include
```

