### PR TITLE
Clarify that file_create()/dir_create() ensure that path exists

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -1,10 +1,10 @@
 #' Create files, directories, or links
 #'
-#' These functions ensure that `path` exists; if it already exists it will
-#' be left unchanged. That means that compared to [file.create()],
-#' `file_create()` will not truncate an existing file, and compared to
-#' [dir.create()], `dir_create()` will silently ignore
-#' existing directories.
+#' The functions `file_create()` and `dir_create()` ensure that `path` exists;
+#' if it already exists it will be left unchanged. That means that compared to
+#' [file.create()], `file_create()` will not truncate an existing file, and
+#' compared to [dir.create()], `dir_create()` will silently ignore existing
+#' directories.
 #'
 #' @template fs
 #' @param mode If file/directory is created, what mode should it have?

--- a/man/create.Rd
+++ b/man/create.Rd
@@ -36,11 +36,11 @@ exist?}
 The path to the created object (invisibly).
 }
 \description{
-These functions ensure that \code{path} exists; if it already exists it will
-be left unchanged. That means that compared to \code{\link[=file.create]{file.create()}},
-\code{file_create()} will not truncate an existing file, and compared to
-\code{\link[=dir.create]{dir.create()}}, \code{dir_create()} will silently ignore
-existing directories.
+The functions \code{file_create()} and \code{dir_create()} ensure that \code{path} exists;
+if it already exists it will be left unchanged. That means that compared to
+\code{\link[=file.create]{file.create()}}, \code{file_create()} will not truncate an existing file, and
+compared to \code{\link[=dir.create]{dir.create()}}, \code{dir_create()} will silently ignore existing
+directories.
 }
 \examples{
 \dontshow{.old_wd <- setwd(tempdir())}


### PR DESCRIPTION
`link_create()` does not ensure that `path` exists (see Issue #231 for an example). Since it is documented in the same man page as `file_create()` and `dir_create()`, I specified that only `file_create()` and `dir_create()` ensure that `path` exists.