### PR TITLE
Follow relative symlinks from their origins

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # fs (development version)
 
+* `file_info(..., follow = TRUE)`, `is_dir()`, and `is_file()`
+  follow relative symlinks in non-current directories (@heavywatal, #280)
+
 * `dir_map()` now grows its internal list safely, the 1.4.0 release introduced an unsafe regression (#268)
 
 * `file_info()` returns a tibble if the tibble package is installed, and subsets work when it is a `data.frame` (#265)

--- a/R/file.R
+++ b/R/file.R
@@ -62,7 +62,9 @@ file_info <- function(path, fail = TRUE, follow = FALSE) {
 
   is_symlink <- !is.na(res$type) & res$type == "symlink"
   while(follow && any(is_symlink)) {
-    res[is_symlink, ] <- file_info(link_path(path[is_symlink]), fail = fail, follow = FALSE)
+    lpath <- link_path(path[is_symlink])
+    lpath <- ifelse(is_absolute_path(lpath), lpath, path(path_dir(path[is_symlink]), lpath))
+    res[is_symlink, ] <- file_info(lpath, fail = fail, follow = FALSE)
     is_symlink <- !is.na(res$type) & res$type == "symlink"
   }
 

--- a/tests/testthat/test-is.R
+++ b/tests/testthat/test-is.R
@@ -2,6 +2,8 @@ context("test-is.R")
 
 with_dir_tree(list("foo/bar"  = "test"), {
   link_create(path_abs("foo/bar"), "foo2")
+  link_create("foo/bar", "relbar")
+  link_create("foo", "relfoo")
 
   describe("is_file", {
     it("returns true for files, false for non-files, NA if no object exists", {
@@ -10,21 +12,29 @@ with_dir_tree(list("foo/bar"  = "test"), {
       expect_false(is_file("foo2", follow = FALSE))
       expect_true(is_file("foo2", follow = TRUE))
       expect_equal(is_file("baz"), c(baz = FALSE))
+      .old_wd <- setwd("foo")
+      expect_false(is_file("../relbar", follow = FALSE))
+      expect_true(is_file("../relbar", follow = TRUE))
+      setwd(.old_wd)
     })
   })
 
   describe("is_dir", {
-    it("returns true for files, false for non-files, NA if no object exists", {
+    it("returns true for dirs, false for non-dirs, NA if no object exists", {
       expect_true(is_dir("foo"))
       expect_false(is_dir("foo/bar"))
       expect_false(is_dir("foo2", follow = FALSE))
       expect_false(is_dir("foo2", follow = TRUE))
       expect_equal(is_dir("baz"), c(baz = FALSE))
+      .old_wd <- setwd("foo")
+      expect_false(is_dir("../relfoo", follow = FALSE))
+      expect_true(is_dir("../relfoo", follow = TRUE))
+      setwd(.old_wd)
     })
   })
 
   describe("is_link", {
-    it("returns true for files, false for non-files, NA if no object exists", {
+    it("returns true for links, false for non-links, NA if no object exists", {
       expect_true(is_link("foo2"))
       expect_false(is_link("foo"))
       expect_false(is_link("foo/bar"))


### PR DESCRIPTION
`file_info()` has been modified to follow relative symlinks properly. This will affect `is_file()` and `is_dir()` as well.