### PR TITLE
Remove structure() calls

### DIFF
--- a/R/fs_bytes.R
+++ b/R/fs_bytes.R
@@ -29,7 +29,8 @@ as_fs_bytes <- function(x) {
 fs_bytes <- as_fs_bytes
 
 new_fs_bytes <- function(x) {
-  structure(x, class = c("fs_bytes", "numeric"))
+  class(x) <- c("fs_bytes", "numeric")
+  x
 }
 setOldClass(c("fs_bytes", "numeric"), numeric())
 

--- a/R/fs_path.R
+++ b/R/fs_path.R
@@ -36,7 +36,9 @@ as_fs_path.character <- function(x) {
 fs_path <- as_fs_path
 
 new_fs_path <- function(x) {
-  structure(enc2utf8(x), class = c("fs_path", "character"))
+  x <- enc2utf8(x)
+  class(x) <- c("fs_path", "character")
+  x
 }
 setOldClass(c("fs_path", "character"), character())
 

--- a/R/fs_perms.R
+++ b/R/fs_perms.R
@@ -169,7 +169,8 @@ as_fs_perms.integer <- function(x, ...) {
 
 new_fs_perms <- function(x) {
   assert("`x` must be an integer", is.integer(x))
-  structure(x, class = c("fs_perms", "integer"))
+  class(x) <- c("fs_perms", "integer")
+  x
 }
 setOldClass(c("fs_perms", "integer"), integer())
 


### PR DESCRIPTION
`structure()` has non-negligible overhead, so replacing it with just a `class()<-` speeds things up.

Old version:

```R
system.time({
  for (i in 1:10000)
    new_fs_path("/foo/bar")
})

#>   user  system elapsed 
#>  0.043   0.000   0.043 
#>
```


With this change:

```R
#>     user  system elapsed 
#>  0.015   0.000   0.015 
```

I know things like this seem small, but they add up, and this is an easy win. With the bootstraplib benchmarking I'm doing, the majority of time is still spent in `fs` calls, even after the file copying change. About 25% of the total time is spent in `path_abs`, which is how I arrived at this change.