### PR TITLE
Fix build errors on AIX and IBM i

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -17,7 +17,7 @@ endif
 ifeq ($(UNAME), OpenBSD)
 PKG_LIBS += -lkvm
 endif
-ifeq ($(UNAME), Linux)
+ifneq ($(filter $(UNAME), Linux AIX OS400),)
 OBJECTS +=  bsd/setmode.o bsd/strmode.o bsd/reallocarray.o
 endif
 

--- a/src/bsd/unistd.h
+++ b/src/bsd/unistd.h
@@ -63,7 +63,6 @@ void closefrom(int lowfd);
 void setproctitle_init(int argc, char *argv[], char *envp[]);
 void setproctitle(const char *fmt, ...);
 
-int getpeereid(int s, uid_t *euid, gid_t *egid);
 __END_DECLS
 
 #endif


### PR DESCRIPTION
Neither provide the BSD getmode/setmode, strmode, or reallocarray so
they need Makevars adjustments to build the libbsd compatibility shims.

In addition, the BSD declaration of getpeereid conflicts with the AIX
definition. Since this function is not used its definition has been
removed.

Fixes #304