### PR TITLE
Fix `dir_copy()` when `length(path)` > 1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fs (development version)
 
+* `dir_copy()` works when `path` has length >1 (#360).
+
 # fs 1.5.1
 
 * Gábor Csárdi is now the maintainer.

--- a/R/copy.R
+++ b/R/copy.R
@@ -83,11 +83,11 @@ dir_copy <- function(path, new_path, overwrite = FALSE) {
     dirs <- dir_ls(path[[i]], type = "directory", recurse = TRUE, all = TRUE)
     dir_create(path(new_path[[i]], path_rel(dirs, path[[i]])))
 
-    files <- dir_ls(path, recurse = TRUE,
+    files <- dir_ls(path[[i]], recurse = TRUE,
       type = c("unknown", "file", "FIFO", "socket", "character_device", "block_device"), all = TRUE)
     file_copy(files, path(new_path[[i]], path_rel(files, path[[i]])), overwrite = overwrite)
 
-    links <- dir_ls(path, recurse = TRUE,
+    links <- dir_ls(path[[i]], recurse = TRUE,
       type = "symlink", all = TRUE)
     link_copy(links, path(new_path[[i]], path_rel(links, path[[i]])), overwrite = overwrite)
   }

--- a/tests/testthat/test-copy.R
+++ b/tests/testthat/test-copy.R
@@ -168,16 +168,15 @@ describe("dir_copy", {
     expect_error(dir_copy(NA, "foo2"), class = "invalid_argument")
     expect_error(dir_copy("foo", NA), class = "invalid_argument")
   })
-})
+  it("dir_copy() works for >1 path", {
+    grandparent_before <- withr::local_tempdir("dir_copy-multiple_paths-before-")
+    grandparent_after <- withr::local_tempdir("dir_copy-multiple_paths-after-")
 
-test_that("dir_copy() works for >1 path", {
-  grandparent_before <- withr::local_tempdir("dir_copy-multiple_paths-before-")
-  grandparent_after <- withr::local_tempdir("dir_copy-multiple_paths-after-")
+    parents <- dir_create(path(grandparent_before, c("alfa", "beta")))
+    file_create(path(parents, c("apple", "banana")))
 
-  parents <- dir_create(path(grandparent_before, c("alfa", "beta")))
-  file_create(path(parents, c("apple", "banana")))
-
-  expect_error_free(
-    dir_copy(parents, path(grandparent_after, path_file(parents)))
-  )
+    expect_error_free(
+      dir_copy(parents, path(grandparent_after, path_file(parents)))
+    )
+  })
 })

--- a/tests/testthat/test-copy.R
+++ b/tests/testthat/test-copy.R
@@ -169,3 +169,15 @@ describe("dir_copy", {
     expect_error(dir_copy("foo", NA), class = "invalid_argument")
   })
 })
+
+test_that("dir_copy() works for >1 path", {
+  grandparent_before <- withr::local_tempdir("dir_copy-multiple_paths-before-")
+  grandparent_after <- withr::local_tempdir("dir_copy-multiple_paths-after-")
+
+  parents <- dir_create(path(grandparent_before, c("alfa", "beta")))
+  file_create(path(parents, c("apple", "banana")))
+
+  expect_error_free(
+    dir_copy(parents, path(grandparent_after, path_file(parents)))
+  )
+})


### PR DESCRIPTION
Sorry I didn't open an issue, but the test shows the failing case. Ran across this in real usage. Also sorry about not writing the test in the `describe()` + `it()` style.