### PR TITLE
remove whitespace

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -18,7 +18,7 @@ extern SEXP fs_copyfile_(SEXP, SEXP, SEXP);
 extern SEXP fs_create_(SEXP, SEXP);
 extern SEXP fs_dir_map_(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP fs_expand_(SEXP, SEXP);
-  extern SEXP fs_exists_(SEXP, SEXP);
+extern SEXP fs_exists_(SEXP, SEXP);
 extern SEXP fs_file_code_(SEXP, SEXP);
 extern SEXP fs_getgrnam_(SEXP);
 extern SEXP fs_getpwnam_(SEXP);


### PR DESCRIPTION
I think this is throwing off clang. We are getting a missing-prototypes warning for `fs_exists_`, this appears to be why?

https://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-prototypes