### PR TITLE
apply as.character before calling enc2utf8 in path_join and path_real

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fs (development version)
 
+* inputs to `path_real()` and `path_join()` are coerced to character for consistency with other functions (@raymondben, #370)
+
 # fs 1.5.2
 
 * `file_create()` and `dir_create()` now return the correct path when `...` arguments are used (@davidchall, #333).

--- a/R/path.R
+++ b/R/path.R
@@ -89,7 +89,7 @@ path_wd <- function(..., ext = "") {
 #'   calls `path_expand()` (literally) and `path_norm()` (effectively).
 #' @export
 path_real <- function(path) {
-  path <- enc2utf8(path)
+  path <- enc2utf8(as.character(path))
   old <- path_expand(path)
 
   is_missing <- is.na(path)
@@ -137,8 +137,8 @@ path_join <- function(parts) {
   if (length(parts) == 0) {
     return(path_tidy(""))
   }
-  if (is.character(parts)) {
-    return(path_tidy(.Call(fs_path_, as.list(enc2utf8(parts)), "")))
+  if (!is.list(parts)) {
+    return(path_tidy(.Call(fs_path_, as.list(enc2utf8(as.character(parts))), "")))
   }
   path_tidy(vapply(parts, path_join, character(1)))
 }

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -143,8 +143,16 @@ describe("path_real", {
       expect_equal(path_real(NA_character_), NA_character_)
       expect_equal(path_real(c("foo2", NA_character_)), c(path_real("foo"), NA_character_))
     })
-
   })
+
+  it("converts inputs to character if required", {
+    with_dir_tree(list("foo/bar" = "test"), {
+      link_create(path_real("foo"), "2") 
+      expect_equal(path_real(NA), NA_character_) ## NA (logical) coerced to NA_character_
+      expect_equal(path_real(2), path_real("2"))
+    })
+  })
+
 })
 
 describe("path_split", {
@@ -205,6 +213,11 @@ describe("path_tidy", {
     out <- fs::path_tidy(x)
     expect_equal(Encoding(out), "UTF-8")
     expect_equal(out, "folder/façile.txt")
+  })
+
+  it("converts inputs to character if required", {
+      expect_equal(path_tidy(c("foo/bar", NA)), c("foo/bar", NA_character_))
+      expect_equal(path_tidy(1), "1")
   })
 })
 
@@ -440,6 +453,18 @@ describe("path_has_parent", {
 
     expect_error(path_has_parent(c("/a/b/c", "x/y"), c("/a/b", "x/y", "foo/bar")), "consistent lengths", class = "invalid_argument")
   })
+})
+
+describe("path_join", {
+    it("converts inputs to character if required", {
+        expect_equal(path_join(c("a", NA)), path_join(c("a", NA_character_)))
+        expect_equal(path_join(c("a", 1)), path_join(c("a", "1")))
+        expect_equal(path_join(list(c("a", 1), c("a/b", 2))), c(path_join(c("a", "1")), path_join(c("a/b", "2"))))
+    })
+    it("works with list inputs", {
+        expect_equal(path_join(list(c("foo", "bar"), c("a/b", "c"))), c(path_join(c("foo", "bar")), path_join(c("a/b", "c"))))
+        expect_equal(path_join(list(NA, c("a", 1), c("a/b", 2))), c(path_join(NA_character_), path_join(c("a", "1")), path_join(c("a/b", "2"))))
+    })
 })
 
 # derived from https://github.com/python/cpython/blob/6f0eb93183519024cb360162bdd81b9faec97ba6/Lib/test/test_posixpath.py#L483

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -147,8 +147,8 @@ describe("path_real", {
 
   it("converts inputs to character if required", {
     with_dir_tree(list("foo/bar" = "test"), {
-      link_create(path_real("foo"), "2") 
-      expect_equal(path_real(NA), NA_character_) ## NA (logical) coerced to NA_character_
+      link_create(path_real("foo"), "2")
+      expect_equal(path_real(NA), fs_path(NA_character_)) ## NA (logical) coerced to NA_character_
       expect_equal(path_real(2), path_real("2"))
     })
   })
@@ -216,8 +216,8 @@ describe("path_tidy", {
   })
 
   it("converts inputs to character if required", {
-      expect_equal(path_tidy(c("foo/bar", NA)), c("foo/bar", NA_character_))
-      expect_equal(path_tidy(1), "1")
+      expect_equal(path_tidy(c("foo/bar", NA)), fs_path(c("foo/bar", NA_character_)))
+      expect_equal(path_tidy(1), fs_path("1"))
   })
 })
 
@@ -459,11 +459,11 @@ describe("path_join", {
     it("converts inputs to character if required", {
         expect_equal(path_join(c("a", NA)), path_join(c("a", NA_character_)))
         expect_equal(path_join(c("a", 1)), path_join(c("a", "1")))
-        expect_equal(path_join(list(c("a", 1), c("a/b", 2))), c(path_join(c("a", "1")), path_join(c("a/b", "2"))))
+        expect_equal(path_join(list(c("a", 1), c("a/b", 2))), fs_path(c(path_join(c("a", "1")), path_join(c("a/b", "2")))))
     })
     it("works with list inputs", {
-        expect_equal(path_join(list(c("foo", "bar"), c("a/b", "c"))), c(path_join(c("foo", "bar")), path_join(c("a/b", "c"))))
-        expect_equal(path_join(list(NA, c("a", 1), c("a/b", 2))), c(path_join(NA_character_), path_join(c("a", "1")), path_join(c("a/b", "2"))))
+        expect_equal(path_join(list(c("foo", "bar"), c("a/b", "c"))), fs_path(c(path_join(c("foo", "bar")), path_join(c("a/b", "c")))))
+        expect_equal(path_join(list(NA, c("a", 1), c("a/b", 2))), fs_path(c(path_join(NA_character_), path_join(c("a", "1")), path_join(c("a/b", "2")))))
     })
 })
 


### PR DESCRIPTION
Per #370 - `enc2utf8(...)` in `path_real` and `path_join` changed to `as.character(enc2utf8(...))` to make behavior consistent with other functions that use `enc2utf8`.