### PR TITLE
Fix libuv for <10.7

### DIFF
--- a/src/libuv-1.44.2/src/unix/core.c
+++ b/src/libuv-1.44.2/src/unix/core.c
@@ -553,18 +553,31 @@ int uv__accept(int sockfd) {
  * will unwind the thread when it's in the cancel state. Work around that
  * by making the system call directly. Musl libc is unaffected.
  */
+
+#if defined(__GNUC__)
+# define GCC_VERSION \
+	(__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#endif
+#if defined(__clang__) || (defined(GCC_VERSION) && (GCC_VERSION >= 40500))
+/* gcc diagnostic pragmas available */
+# define GCC_DIAGNOSTIC_AVAILABLE
+#endif
 int uv__close_nocancel(int fd) {
-#if defined(__APPLE__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdollar-in-identifier-extension"
-#if defined(__LP64__) || TARGET_OS_IPHONE
+#if defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)
+# if defined(GCC_DIAGNOSTIC_AVAILABLE)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdollar-in-identifier-extension"
+# endif
+# if defined(__LP64__) || __LP64__ || (defined(TARGET_OS_IPHONE) && (TARGET_OS_IPHONE > 0))
   extern int close$NOCANCEL(int);
   return close$NOCANCEL(fd);
-#else
+# else
   extern int close$NOCANCEL$UNIX2003(int);
   return close$NOCANCEL$UNIX2003(fd);
-#endif
-#pragma GCC diagnostic pop
+# endif
+# if defined(GCC_DIAGNOSTIC_AVAILABLE)
+#  pragma GCC diagnostic pop
+# endif
 #elif defined(__linux__) && defined(__SANITIZE_THREAD__) && defined(__clang__)
   long rc;
   __sanitizer_syscall_pre_close(fd);

--- a/src/libuv-1.44.2/src/unix/darwin-proctitle.c
+++ b/src/libuv-1.44.2/src/unix/darwin-proctitle.c
@@ -41,9 +41,11 @@ static int uv__pthread_setname_np(const char* name) {
   strncpy(namebuf, name, sizeof(namebuf) - 1);
   namebuf[sizeof(namebuf) - 1] = '\0';
 
+#if TARGET_OS_IPHONE || (MAC_OS_X_VERSION_MIN_REQUIRED >= 1060)
   err = pthread_setname_np(namebuf);
   if (err)
     return UV__ERR(err);
+#endif
 
   return 0;
 }

--- a/src/libuv-1.44.2/src/unix/fs.c
+++ b/src/libuv-1.44.2/src/unix/fs.c
@@ -1061,7 +1061,7 @@ static ssize_t uv__fs_sendfile(uv_fs_t* req) {
 
     return -1;
   }
-#elif defined(__APPLE__)           || \
+#elif (defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)) || \
       defined(__DragonFly__)       || \
       defined(__FreeBSD__)         || \
       defined(__FreeBSD_kernel__)
@@ -1441,7 +1441,7 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
   dst->st_blksize = src->st_blksize;
   dst->st_blocks = src->st_blocks;
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)
   dst->st_atim.tv_sec = src->st_atimespec.tv_sec;
   dst->st_atim.tv_nsec = src->st_atimespec.tv_nsec;
   dst->st_mtim.tv_sec = src->st_mtimespec.tv_sec;

--- a/src/libuv-1.44.2/src/unix/process.c
+++ b/src/libuv-1.44.2/src/unix/process.c
@@ -36,7 +36,9 @@
 #include <poll.h>
 
 #if defined(__APPLE__)
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
 # include <spawn.h>
+#endif
 # include <paths.h>
 # include <sys/kauth.h>
 # include <sys/types.h>
@@ -387,7 +389,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
 #endif
 
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
 typedef struct uv__posix_spawn_fncs_tag {
   struct {
     int (*addchdir_np)(const posix_spawn_file_actions_t *, const char *);
@@ -588,9 +590,11 @@ static int uv__spawn_set_posix_spawn_file_actions(
       }
     }
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
     if (fd == use_fd)
         err = posix_spawn_file_actions_addinherit_np(actions, fd);
     else
+#endif
         err = posix_spawn_file_actions_adddup2(actions, use_fd, fd);
     assert(err != ENOSYS);
     if (err != 0)
@@ -839,7 +843,7 @@ static int uv__spawn_and_init_child(
   int exec_errorno;
   ssize_t r;
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
   uv_once(&posix_spawn_init_once, uv__spawn_init_posix_spawn);
 
   /* Special child process spawn case for macOS Big Sur (11.0) onwards

--- a/src/libuv-1.44.2/src/unix/tty.c
+++ b/src/libuv-1.44.2/src/unix/tty.c
@@ -85,7 +85,7 @@ static int uv__tty_is_slave(const int fd) {
   int dummy;
 
   result = ioctl(fd, TIOCGPTN, &dummy) != 0;
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
   char dummy[256];
 
   result = ioctl(fd, TIOCPTYGNAME, &dummy) != 0;

--- a/src/libuv-1.44.2/src/unix/udp.c
+++ b/src/libuv-1.44.2/src/unix/udp.c
@@ -938,6 +938,7 @@ static int uv__udp_set_membership6(uv_udp_t* handle,
     !defined(__ANDROID__) &&                                        \
     !defined(__DragonFly__) &&                                      \
     !defined(__QNX__) &&                                            \
+    (!defined(__APPLE__) || (MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)) && \
     !defined(__GNU__)
 static int uv__udp_set_source_membership4(uv_udp_t* handle,
                                           const struct sockaddr_in* multicast_addr,
@@ -1131,6 +1132,7 @@ int uv_udp_set_source_membership(uv_udp_t* handle,
     !defined(__ANDROID__) &&                                        \
     !defined(__DragonFly__) &&                                      \
     !defined(__QNX__) &&                                            \
+    (!defined(__APPLE__) || (MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)) && \
     !defined(__GNU__)
   int err;
   union uv__sockaddr mcast_addr;


### PR DESCRIPTION
The patch fixes the build on older MacOS and is based on Macports one: https://github.com/macports/macports-ports/blob/master/devel/libuv/files/patch-libuv-legacy.diff