### PR TITLE
Fix for dev testhat

### DIFF
--- a/tests/testthat/test-fs_path.R
+++ b/tests/testthat/test-fs_path.R
@@ -27,7 +27,7 @@ describe("as_fs_path", {
 describe("colourise_fs_path", {
   it("returns an appropriately colored fs_path object", {
     withr::local_envvar(c("LS_COLORS" = gnu_ls_defaults))
-    withr::local_options(c(crayon.enabled = TRUE))
+    local_reproducible_output(crayon = TRUE)
 
     with_dir_tree(
       list(


### PR DESCRIPTION
`it()` now calls `local_reproducible_output()`

Could you please also plan for a patch release in the next two weeks?