### PR TITLE
Pass `CPPFLAGS` separately to `libuv`'s configure script

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -29,7 +29,7 @@ $(SHLIB): $(LIBUV)/.libs/libuv.a
 
 $(LIBUV)/Makefile:
 	(cd $(LIBUV) \
-	&& CC="$(CC)" CFLAGS="$(CFLAGS) $(CPPFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -std=c99" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure --quiet)
+	&& CC="$(CC)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -std=c99" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure --quiet)
 
 $(LIBUV)/.libs/libuv.a: $(LIBUV)/Makefile
 	$(MAKE) --directory=$(LIBUV) \


### PR DESCRIPTION
Do not combine `CPPFLAGS` into `CFLAGS` because `CFLAGS` is passed to the linker when buiding `libuv`. If `CPPFLAGS` contains `-Xclang -fopenmp`, it will confuse the linker and produces error `clang: error: unsupported option '-fopenmp'`. See:
https://github.com/libuv/libuv/discussions/3966

Closes #345.