### PR TITLE
remove duplicate link in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,9 +14,7 @@ Authors@R: c(
 Description: A cross-platform interface to file system operations, built
     on top of the 'libuv' C library.
 License: MIT + file LICENSE
-URL: https://fs.r-lib.org,
-    https://github.com/r-lib/fs,
-    https://fs.r-lib.org/
+URL: https://fs.r-lib.org, https://github.com/r-lib/fs
 BugReports: https://github.com/r-lib/fs/issues
 Depends: 
     R (>= 3.4)


### PR DESCRIPTION
The pkgdown link was there twice in the URL field.