### PR TITLE
Move <Rinternals> include after <vector>

### DIFF
--- a/src/file.cc
+++ b/src/file.cc
@@ -2,8 +2,6 @@
 #define __STDC_FORMAT_MACROS 1
 #endif
 
-#include <Rinternals.h>
-
 #include "getmode.h"
 #include "uv.h"
 
@@ -12,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include <Rinternals.h>
 #include "error.h"
 
 #ifndef __WIN32

--- a/src/id.cc
+++ b/src/id.cc
@@ -1,7 +1,8 @@
-#include "utils.h"
-#include <Rinternals.h>
 #include <string>
 #include <vector>
+
+#include <Rinternals.h>
+#include "utils.h"
 
 #ifndef __WIN32
 #include <grp.h>


### PR DESCRIPTION
Future releases of `<vector>` may cause issues interacting with R's `length()` macro that this change helps avoid