### PR TITLE
Pass R_CONFIGURE_FLAGS when configuring libuv

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -29,7 +29,7 @@ $(SHLIB): $(LIBUV)/.libs/libuv.a
 
 $(LIBUV)/Makefile:
 	(cd $(LIBUV) \
-	&& CC="$(CC)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -std=c99" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure --quiet)
+	&& CC="$(CC)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -std=c99" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(R_CONFIGURE_FLAGS) --quiet)
 
 $(LIBUV)/.libs/libuv.a: $(LIBUV)/Makefile
 	$(MAKE) --directory=$(LIBUV) \


### PR DESCRIPTION
Currently the build fails when cross compiling for wasm or macos, because autoconf wants to get a `--host` flag. See for example build logs here: https://github.com/r-universe/r-lib/actions/runs/7467210469/job/20320359273

I think the easiest solution is to use the same flags as we use for R `configure` scripts.

An alternative would be to introduce a new variable to specifically set the `--host` variable, but I think this just introduces needless complexity. The libuv configure seems to ignore arguments that it does not know, so if R_CONFIGURE_FLAGS would contain additional parameters on some platforms, that should not matter either.

@georgestagg @tylfin

