### PR TITLE
Fix table mistake in function-comparisons.Rmd

### DIFF
--- a/vignettes/function-comparisons.Rmd
+++ b/vignettes/function-comparisons.Rmd
@@ -72,7 +72,7 @@ base R functions:
 | `file_show("path")`                         | `browseURL("path")`               | `open path`                       |
 | `file_touch()`                              | *No direct equivalent*            | `touch path`                      |
 | `file_temp()`                               | `tempfile()`                      | `mktemp`                          |
-| `file_test()`                               | *No direct equivalent*            | `if [ -d "path" ]; then ...; fi`  |
+|  *No direct equivalent*                     | `file_test()`                     | `if [ -d "path" ]; then ...; fi`  |
 
 ## Path functions
 


### PR DESCRIPTION
`file_test()` is in the `fs` column but is a base function (from `utils`), there isn't an `fs` equivalent, as far as I know...

I think the mistake was because it follows the naming convention used by `fs`.