### PR TITLE
`path_ext_remove()` returns correct path if multiple dots present

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -368,7 +368,7 @@ path_ext <- function(path) {
 #' @export
 path_ext_remove <- function(path) {
   dir <- path_dir(path)
-  file <- sub("(?<!^|[.]|/)[.][^.]+$", "", path_file(path), perl = TRUE)
+  file <- sub("(?<!^|[.])\\.+([^.]+)$", "", path_file(path), perl = TRUE)
 
   na <- is.na(path)
   no_dir <- dir == "." | dir == ""

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -293,6 +293,8 @@ describe("path_ext_remove", {
     expect_equal(path_ext_remove(".cshrc"), ".cshrc")
     expect_equal(path_ext_remove("...manydots"), "...manydots")
     expect_equal(path_ext_remove("...manydots.ext"), "...manydots")
+    expect_equal(path_ext_remove("manydots..."), "manydots...")
+    expect_equal(path_ext_remove("manydots...ext"), "manydots")
     expect_equal(path_ext_remove("."), ".")
     expect_equal(path_ext_remove(".."), "..")
     expect_equal(path_ext_remove("........"), "........")


### PR DESCRIPTION
Follow-up on https://github.com/r-lib/fs/pull/452, which dealt only with `path_ext()`.