### PR TITLE
`path_rel()` provides an informative error message when multiple starting directory paths are specified

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # fs (development version)
 
-* `path_ext()` returns extension when multiple dots are present in file name (@IndrajeetPatil, #452).
+* `path_ext()` and `path_ext_remove()` return correct extension and path, respectively, when multiple dots are present in file name (@IndrajeetPatil, #452, #453).
+
+* `path_rel()` provides an informative error message when multiple starting directory paths are specified (@IndrajeetPatil).
 
 # fs 1.6.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `path_ext()` and `path_ext_remove()` return correct extension and path, respectively, when multiple dots are present in file name (@IndrajeetPatil, #452, #453).
 
-* `path_rel()` provides an informative error message when multiple starting directory paths are specified (@IndrajeetPatil).
+* `path_rel()` provides an informative error message when multiple starting directory paths are specified (@IndrajeetPatil, #454).
 
 # fs 1.6.4
 

--- a/R/path.R
+++ b/R/path.R
@@ -201,6 +201,10 @@ path_norm <- function(path) {
 # This implementation is partially derived from
 # https://github.com/python/cpython/blob/9c99fd163d5ca9bcc0b7ddd0d1e3b8717a63237c/Lib/posixpath.py#L446
 path_rel <- function(path, start = ".") {
+  if (length(start) > 1L) {
+    stop("`start` must be a single path to a starting directory.", call. = FALSE)
+  }
+
   start <- path_abs(path_expand(start))
   path <- path_abs(path_expand(path))
 

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -604,6 +604,11 @@ describe("path_rel", {
       path_rel(c("a", "a/b", "a/b/c"), "a/b"),
       fs_path(c("..", ".", "c"))
     )
+    expect_error(
+      path_rel(c("a", "a/b", "a/b/c"), c("a/b", "a")),
+      "`start` must be a single path to a starting directory",
+      fixed = TRUE
+    )
   })
 
   it("works for windows paths", {


### PR DESCRIPTION
Closes #408