### PR TITLE
Directly include system headers

### DIFF
--- a/src/dir.cc
+++ b/src/dir.cc
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <limits>
+#include <string>
 #include <sys/stat.h>
 
 #include "getmode.h"

--- a/src/file.cc
+++ b/src/file.cc
@@ -2,6 +2,7 @@
 #define __STDC_FORMAT_MACROS 1
 #endif
 
+#include <cstdio>
 #include <string>
 #include <vector>
 #include <inttypes.h>

--- a/src/id.cc
+++ b/src/id.cc
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/src/path.cc
+++ b/src/path.cc
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 #include "Rinternals.h"
 #include "error.h"

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,3 +1,5 @@
+#include <cctype>
+#include <cstddef>
 #include <string>
 
 #include "utils.h"


### PR DESCRIPTION
Found by `clang-tidy`:

https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html

 - cstddef --> size_t
 - cstdio --> snprintf()
 - cctype --> toupper()
 - string --> std::string()

There are several other findings related to `libuv` that I'm omitting here e.g.

> no header providing "uv_fs_req_cleanup" is directly included

As well as ones that are really not standard for R packages:

> no header providing "NULL" is directly included

Happy to provide the full output if requested; sticking to a more minimal version of standard system headers here for now.