### PR TITLE
Avoid running autotools at install time

### DIFF
--- a/.github/workflows/dragonflybsd.yaml
+++ b/.github/workflows/dragonflybsd.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install system requirements
         run: |
-          pkg install -y autoconf automake libtool hs-pandoc
+          pkg install -y hs-pandoc
         shell: dragonflybsd {0}
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/freebsd.yaml
+++ b/.github/workflows/freebsd.yaml
@@ -42,9 +42,7 @@ jobs:
 
       - name: Install system requirements
         run: |
-          pkg install -y hs-pandoc autoconf automake libtool
-          ln -s aclocal /usr/local/bin/aclocal-1.16
-          ln -s automake /usr/local/bin/automake-1.16
+          pkg install -y hs-pandoc
         shell: freebsd {0}
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/netbsd.yaml
+++ b/.github/workflows/netbsd.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install system dependencies
         shell: netbsd {0}
         run: |
-          pkg_add autoconf automake libtool pandoc png
+          pkg_add pandoc png
           # these do not work in the end, but I'll leave them here
           ln -s libpng16.so /usr/pkg/lib/libpng.so
           ln -s libfontconfig.so /usr/pkg/lib/libfontconfig.so.2

--- a/.github/workflows/openbsd.yaml
+++ b/.github/workflows/openbsd.yaml
@@ -45,8 +45,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          pkg_add -I pandoc automake-1.16.5 libtool
-          echo 'export AUTOCONF_VERSION=2.69' >> /etc/profile
+          pkg_add -I pandoc
         shell: openbsd {0}
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/src/Makevars
+++ b/src/Makevars
@@ -30,7 +30,10 @@ all: $(SHLIB)
 
 $(SHLIB): $(LIBUV)/.libs/libuv.a
 
+# Avoid re-running autoconf/automake/aclocal.
+# Need the timestamps in the right order.
 $(LIBUV)/Makefile:
+	touch $(LIBUV)/aclocal.m4 && touch $(LIBUV)/configure && touch $(LIBUV)/Makefile.in
 	(cd $(LIBUV) \
 	&& CC="$(CC)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -std=c99" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(R_CONFIGURE_FLAGS) --quiet)
 


### PR DESCRIPTION
Depending on the timestamps in the git checkout
or the built package, `make` might trigger an
`autoconf`, `automake` or `aclocal` re-run when
configuring libuv. Now we set up the timestamps
in the correct order, so such re-run does not
happen