### PR TITLE
docs: fix is_*() return value for nonexistent paths (#516)

### DIFF
--- a/R/is.R
+++ b/R/is.R
@@ -1,7 +1,7 @@
 #' Functions to test for file types
 #'
 #' @return A named logical vector, where the names give the paths. If the given
-#'   object does not exist, `NA` is returned.
+#'   object does not exist, `FALSE` is returned.
 #' @seealso [file_exists()], [dir_exists()] and [link_exists()] if you want
 #'   to ensure that the path also exists.
 #' @template fs

--- a/man/is_file.Rd
+++ b/man/is_file.Rd
@@ -23,7 +23,7 @@ the results will be that of the final file rather than the link.}
 }
 \value{
 A named logical vector, where the names give the paths. If the given
-object does not exist, \code{NA} is returned.
+object does not exist, \code{FALSE} is returned.
 }
 \description{
 Functions to test for file types


### PR DESCRIPTION
## Summary

The documentation for `is_file()`, `is_dir()`, `is_link()`, and `is_file_empty()` states that `NA` is returned for nonexistent paths. The actual behavior (since at least the current implementation) is to return `FALSE`.

This PR updates the `@return` documentation to match the implementation.

## Related issue

Fixes #516

## Changes

- `R/is.R:4` — Change `NA` to `FALSE` in `@return` roxygen tag
- `man/is_file.Rd:26` — Regenerated Rd matching the roxygen source

## Validation

- `tools::checkRd('man/is_file.Rd')` passes with no warnings
- Diff is 2 lines in 2 files, doc-only

## Reproducible example

```r
fs::is_file("nonexistent")
#> nonexistent 
#>       FALSE
# Expected per docs: NA
# Actual: FALSE
```
