### PR TITLE
Improve path_rel performance

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -226,9 +226,7 @@ path_rel <- function(path, start = ".") {
     return(path_tidy(NA_character_))
   }
 
-  unique_paths <- unique(path)
-  unique_out <- path_rel_impl(unique_paths, start)
-  path <- unique_out[match(path, unique_paths)]
+  path <- call_with_deduplication(path_rel_impl)(path, start)
 
   # Call path_tidy after deduplication to ensure the right output format.
   path_tidy(path)

--- a/R/path.R
+++ b/R/path.R
@@ -223,15 +223,25 @@ path_rel <- function(path, start = ".") {
   start <- path_abs(path_expand(start))
   path <- path_abs(path_expand(path))
 
-  path_rel_one <- function(p) {
-    common <- path_common(c(start, p))
-    starts <- path_split(start)[[1]]
-    paths <- path_split(p)[[1]]
+  if (is.na(start)) {
+    return(path_tidy(NA_character_))
+  }
 
-    i <- length(path_split(common)[[1]])
+
+  starts <- path_split(start)[[1]]
+
+  is_missing <- is.na(path)
+  split_paths_list <- path_split(path[!is_missing])
+
+  # path_rel_one() is called once per element of `path`, so its argument is a
+  # single vector of the split components of a single path.
+  path_rel_one <- function(path_parts) {
+    common <- path_common_parts(starts, path_parts)
+
+    i <- length(common)
     double_dot_part <- rep("..", (length(starts) - i))
-    if (i + 1 <= length(paths)) {
-      path_part <- paths[seq(i + 1, length(paths))]
+    if (i + 1 <= length(path_parts)) {
+      path_part <- path_parts[seq(i + 1, length(path_parts))]
     } else {
       path_part <- character()
     }
@@ -242,13 +252,8 @@ path_rel <- function(path, start = ".") {
 
     path_join(rels)
   }
-  if (is.na(start)) {
-    return(path_tidy(NA_character_))
-  }
 
-  is_missing <- is.na(path)
-
-  path[!is_missing] <- vapply(path[!is_missing], path_rel_one, character(1))
+  path[!is_missing] <- vapply(split_paths_list, path_rel_one, character(1))
 
   path_tidy(path)
 }
@@ -460,22 +465,44 @@ path_common <- function(path) {
   path <- path_norm(path)
   path <- sort(path)
 
-  # remove . entries from the split paths
-  parts <- lapply(path_split(path), function(x) x[x != "."])
+  parts <- path_split(path)
   s1 <- parts[[1]]
   s2 <- parts[[length(parts)]]
-  common <- s1
-  for (i in seq_along(s1)) {
-    if (s1[[i]] != s2[[i]]) {
-      if (i == 1) {
-        common <- ""
-      } else {
-        common <- s1[seq(1, i - 1)]
-      }
-      break
-    }
-  }
+  common <- path_common_parts(s1, s2)
   path_join(common)
+}
+
+#' Find the common leading components of two already-split paths
+#'
+#' This is the shared primitive behind both [path_common()] (which reduces
+#' its general, possibly-N-path input down to exactly two vectors -- the
+#' lexicographic min and max after `sort()` -- before comparing them) and
+#' [path_rel()] (which always compares exactly two paths: `start` and one
+#' element of `path`).
+#'
+#' @param s1,s2 Character vectors of path components, as returned by a single
+#'   element of [path_split()], e.g. `path_split("/foo/bar")[[1]]`, which is
+#'   `c("/foo", "bar")`. Need not be pre-normalized: `.` entries are stripped
+#'   internally, so it's safe to call this with components straight from
+#'   `path_split()` even if they haven't been through [path_norm()].
+#' @return A character vector of the shared leading components of `s1` and
+#'   `s2`, e.g. `path_common_parts(c("/foo", "bar"), c("/foo", "baz"))`
+#'   returns `"/foo"`.
+#' @noRd
+path_common_parts <- function(s1, s2) {
+  s1 <- s1[s1 != "."]
+  s2 <- s2[s2 != "."]
+
+  n <- min(length(s1), length(s2))
+  if (n == 0) {
+    return(character(0))
+  }
+
+  eq <- s1[seq_len(n)] == s2[seq_len(n)]
+  first_diff <- match(FALSE, eq)
+  i <- if (is.na(first_diff)) n else first_diff - 1L
+
+  if (i == 0) character(0) else s1[seq_len(i)]
 }
 
 #' Filter paths

--- a/R/path.R
+++ b/R/path.R
@@ -221,13 +221,23 @@ path_rel <- function(path, start = ".") {
   }
 
   start <- path_abs(path_expand(start))
-  path <- path_abs(path_expand(path))
 
   if (is.na(start)) {
     return(path_tidy(NA_character_))
   }
 
+  path <- path_abs(path_expand(path))
 
+  unique_paths <- unique(path)
+  unique_out <- path_rel_impl(unique_paths, start)
+  path <- unique_out[match(path, unique_paths)]
+
+  # Call path_tidy after deduplication to ensure the right output format.
+  path_tidy(path)
+}
+
+# Implementation of path_rel, deduplicated in actual usage above.
+path_rel_impl <- function(path, start) {
   starts <- path_split(start)[[1]]
 
   is_missing <- is.na(path)
@@ -255,7 +265,7 @@ path_rel <- function(path, start = ".") {
 
   path[!is_missing] <- vapply(split_paths_list, path_rel_one, character(1))
 
-  path_tidy(path)
+  path
 }
 
 #' Finding the User Home Directory

--- a/R/path.R
+++ b/R/path.R
@@ -244,9 +244,9 @@ path_rel_impl <- function(path, start) {
   # path_rel_one() is called once per element of `path`, so its argument is a
   # single vector of the split components of a single path.
   path_rel_one <- function(path_parts) {
-    common <- path_common_parts(starts, path_parts)
+    common_parts <- path_common_parts(starts, path_parts)
 
-    i <- length(common)
+    i <- length(common_parts)
     double_dot_part <- rep("..", (length(starts) - i))
     if (i + 1 <= length(path_parts)) {
       path_part <- path_parts[seq(i + 1, length(path_parts))]
@@ -476,8 +476,8 @@ path_common <- function(path) {
   parts <- path_split(path)
   s1 <- parts[[1]]
   s2 <- parts[[length(parts)]]
-  common <- path_common_parts(s1, s2)
-  path_join(common)
+  common_parts <- path_common_parts(s1, s2)
+  path_join(common_parts)
 }
 
 #' Find the common leading components of two already-split paths

--- a/R/path.R
+++ b/R/path.R
@@ -226,8 +226,6 @@ path_rel <- function(path, start = ".") {
     return(path_tidy(NA_character_))
   }
 
-  path <- path_abs(path_expand(path))
-
   unique_paths <- unique(path)
   unique_out <- path_rel_impl(unique_paths, start)
   path <- unique_out[match(path, unique_paths)]
@@ -238,6 +236,8 @@ path_rel <- function(path, start = ".") {
 
 # Implementation of path_rel, deduplicated in actual usage above.
 path_rel_impl <- function(path, start) {
+  path <- path_abs(path_expand(path))
+
   starts <- path_split(start)[[1]]
 
   is_missing <- is.na(path)

--- a/R/path.R
+++ b/R/path.R
@@ -226,7 +226,7 @@ path_rel <- function(path, start = ".") {
     return(path_tidy(NA_character_))
   }
 
-  path <- call_with_deduplication(path_rel_impl)(path, start)
+  path <- call_with_deduplication(path_rel_impl, path, start)
 
   # Call path_tidy after deduplication to ensure the right output format.
   path_tidy(path)


### PR DESCRIPTION
#519 

Improved `path_rel` performance by:
1. Hoisting `path_split(start)` out of the loop entirely.
2. Performing `path_split(path)` in a single vectorized call outside the R loop.
3. Adding a new, internal `path_common_parts` that takes the components, rather than having to split again, and then passing the vectorized-split parts directly.
4. The internal `path_common_parts` uses vectorized calls rather than R loops.
5. Deduplicating `path` input to `path_rel`.

Performance Improvement:
* ~10x improvement on 5k vector with no duplication (1.77 -> 200ms)
* ~350x improvement on 5k vector with 50x duplication (2.09s -> 6ms)

Tests pass:
```
[ FAIL 0 | WARN 0 | SKIP 5 | PASS 280 ]

── Skipped tests (5) ────────────────────────────────────────────────────────────────────────────────────────────────────────
• On Windows (5): test-path.R:118:5, test-path.R:129:5, test-path.R:148:5, test-path.R:161:5, test-path.R:716:5
```

## Benchmark

``` r
# Load dev path_rel and path_common
devtools::load_all("D:/Github/fs")
#> ℹ Loading fs

# Original path_rel and path_common
original_path_common <- function(path) {
  ...  # Copied from fs
}
original_path_rel <- function(path, start = ".") {
  ...  # Copied from fs, except using original_path_common()
}

all_3_letter_combos <- do.call(paste0, expand.grid(rep(list(LETTERS), 3)))

set.seed(3)
top_path <- "x/y/"

# Case 1: No duplication
paths <- paste0(top_path, sample(all_3_letter_combos, 5000), "/file.csv")
str(paths)
#>  chr [1:5000] "x/y/OHQ/file.csv" "x/y/JXJ/file.csv" "x/y/DDK/file.csv" ...

## path_rel()
microbenchmark::microbenchmark(
  new = path_rel(paths, start=top_path),
  original = original_path_rel(paths, start=top_path),
  times = 10L
)
#> Unit: milliseconds
#>      expr       min        lq      mean    median        uq      max neval cld
#>       new  181.1754  183.2254  256.2644  200.0344  344.2702  383.949    10  a 
#>  original 1723.4413 1757.3969 1920.8330 1769.0271 1786.6630 2693.200    10   b

## path_common()
microbenchmark::microbenchmark(
  new = path_common(paths),
  original = original_path_common(paths),
  times = 10L
)
#> Unit: milliseconds
#>      expr     min      lq     mean  median      uq     max neval cld
#>       new 71.0870 72.2124 79.92248 79.7240 85.2738 97.9682    10   a
#>  original 76.5306 77.0471 82.81926 83.1001 88.1458 89.9067    10   a


# Case 2: With duplication

# Create a list with significant duplication (50x duplication).
dup_paths <- sample(paths, length(paths) / 50) |> 
  rep(50) |> 
  sample()  # Reshuffle to ensure no sort-based benefits.
str(dup_paths)
#>  chr [1:5000] "x/y/EBC/file.csv" "x/y/ZUI/file.csv" "x/y/XSC/file.csv" ...

## path_rel()
microbenchmark::microbenchmark(
  new = path_rel(dup_paths, start=top_path),
  original = original_path_rel(dup_paths, start=top_path),
  deduped_og = deduped::deduped(original_path_rel)(dup_paths, start=top_path),
  deduped_new = deduped::deduped(path_rel)(dup_paths, start=top_path),
  times = 10L
)
#> Unit: milliseconds
#>         expr       min        lq       mean     median        uq       max neval cld
#>          new    4.9530    6.0521    6.29429    6.32245    6.3719    8.5303    10  a 
#>     original 1883.7256 1989.1657 2137.89882 2092.36985 2314.7633 2428.3711    10   b
#>   deduped_og   34.9242   39.0378   44.23877   40.64605   42.8788   68.3704    10  a 
#>  deduped_new    4.7585    5.6040   17.32869    5.80520    6.1606  119.5408    10  a 

## path_common()
microbenchmark::microbenchmark(
  new = path_common(dup_paths),
  original = original_path_common(dup_paths),
  times = 10L
)
#> Unit: milliseconds
#>      expr     min      lq     mean   median      uq     max neval cld
#>       new 72.1070 72.7383 76.19327 74.94015 79.1212 84.9619    10  a 
#>  original 73.5073 76.5788 87.99847 91.37255 97.9526 99.3352    10   b
```

<sup>Created on 2026-07-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
